### PR TITLE
Add GitHub action to publish crate to the registry

### DIFF
--- a/.github/workflows/publish-crate.yaml
+++ b/.github/workflows/publish-crate.yaml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Publish crate
+
+jobs:
+  release:
+    name: Publish crate
+    env:
+      PROJECT_NAME: self-assessment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Merging a PR to main should trigger a release to the crate registry (crates.io)