### PR TITLE
Specify paths for Pubish Github Action

### DIFF
--- a/.github/workflows/publish-crate.yaml
+++ b/.github/workflows/publish-crate.yaml
@@ -2,7 +2,11 @@ on:
   push:
     branches:
       - main
-
+    paths:
+      - 'src/**'
+      - '**/Cargo.lock'
+      - '**/Cargo.toml'
+      
 name: Publish crate
 
 jobs:


### PR DESCRIPTION
Should not attempt to update the crate registry if the change doesn't involve the CLI tool itself.