### PR TITLE
V0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 # Change Log
 All notable changes to this project will be documented in this file.
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+
+# Change Log
+All notable changes to this project will be documented in this file.
+ 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+ 
+## [0.1.1] - 2022-02-16
+ 
+### Added
+- The tool now outputs descriptive status updates when running.
+- The `GuardianPullRequests` enum now implements the `Display` trait.
+ 
+### Changed
+- In order to decrease the likelihood of hitting GitHub's secondary rate limit, the logic has been changed so that polling stops once the number of fetched items matches the number of the total items in the response. 
+- The `Args` struct now lives in its own module (`cli.rs`).
+- The `body` field in the `GithubSearchResponseItem` struct has been changed from a `String` type to an `Option<String>` type to account for empty PR descriptions.
+
+### Fixed
+- The new `body` type (`Option<String>`) means that execution no longer halts when encountering a pull request with an empty body.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "self-assessment"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "colorsys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self-assessment"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub organisation."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ It is not meant to be the be-all and end-all of the self-assessment journey. Use
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-2. Run `cargo install self-assessment` to install the CLI tool.
+2. Run `cargo install self-assessment` to install or update the CLI tool to the latest version.
 
-3. You can now use the CLI tool! But first, you need to generate a GitHub personal access token 👉 [here](https://github.com/settings/tokens/new) 👈\
+3. You can now start using the CLI tool! But first, you need to generate a GitHub personal access token 👉 [here](https://github.com/settings/tokens/new) 👈\
+This is required for the tool to access your pull requests in private repositories within the Guardian organisation.\
 Set your preferred expiration date and make sure you grant the **repo** scopes (avoid "No expiration" for security reasons). Finally, click "Generate token".\
 **NB**: You will need to re-authenticate once the token expires.
 <img width="744" alt="image" src="https://user-images.githubusercontent.com/57295823/153786937-19a8bda1-2d2c-4df2-9fd0-682b6a15228f.png">
@@ -37,19 +38,22 @@ Omitting one of the two flags also works (e.g `self-assessment --from 2021-10-01
 
 If all goes well, you should see an automatically generated HTML page containing useful information about PRs authored and reviewed by you.
 
-<img width="1769" alt="image" src="https://user-images.githubusercontent.com/57295823/153787048-c8b8174b-ce81-43c2-9620-52ddc7077848.png">
+<img width="1766" alt="image" src="https://user-images.githubusercontent.com/57295823/154172206-6e7212c6-9d82-45d4-9937-c13c19177f5e.png">
 <img width="1765" alt="image" src="https://user-images.githubusercontent.com/57295823/153787265-5afab18f-d26b-4357-acd9-2f999206b440.png">
 
 ## CLI information
 ```
-self-assessment 0.1.0
+self-assessment 0.1.1
+A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub
+organisation.
 
 USAGE:
     self-assessment [OPTIONS]
 
 OPTIONS:
-    -a, --auth-token <AUTH_TOKEN>    Github authentication token. This is needed to run the CLI
-                                     tool. You can get a personal access token at
+    -a, --auth-token <AUTH_TOKEN>    Github authentication token. This is needed for the CLI tool to
+                                     access Guardian's private repositories to which the user has
+                                     access. You can get a personal access token at
                                      https://github.com/settings/tokens/new [default: ]
     -f, --from <FROM>                Match PRs that were created after this date [default: *]
     -h, --help                       Print help information

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-
 use clap::Parser;
 use serde::Serialize;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ pub struct Args {
     pub to: String,
 
     /// Github authentication token. This is needed for the CLI tool to access
-    /// Guardian's private repositories to which the user has access.
+    /// the Guardian's private repositories to which the user has access.
     /// You can get a personal access token at https://github.com/settings/tokens/new
     #[clap(short, long, default_value = "")]
     #[serde(rename = "auth-token")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,22 @@
+
+use clap::Parser;
+use serde::Serialize;
+
+#[derive(Parser, Debug, Serialize)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// Match PRs that were created after this date
+    #[clap(short, long, default_value = "*")]
+    pub from: String,
+
+    /// Match PRs that were created up until this date
+    #[clap(short, long, default_value = "*")]
+    pub to: String,
+
+    /// Github authentication token. This is needed for the CLI tool to access
+    /// Guardian's private repositories to which the user has access.
+    /// You can get a personal access token at https://github.com/settings/tokens/new
+    #[clap(short, long, default_value = "")]
+    #[serde(rename = "auth-token")]
+    pub auth_token: String,
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -13,7 +13,7 @@ use std::process;
 use std::{borrow::Cow, collections::HashMap};
 use url::Url;
 
-pub fn get_auth_token(args: &crate::models::Args) -> Result<String, Box<dyn Error>> {
+pub fn get_auth_token(args: &crate::cli::Args) -> Result<String, Box<dyn Error>> {
     let env_var_path = format!("{}/.selfassessment", shellexpand::tilde("~/"));
 
     if !args.auth_token.is_empty() {
@@ -71,7 +71,7 @@ pub async fn search_pull_requests<'a>(
     client: &Octocrab,
     pr_type: GuardianPullRequests,
     params: &mut HashMap<&'static str, Cow<'a, str>>,
-    args: &crate::models::Args,
+    args: &crate::cli::Args,
 ) -> Vec<GithubSearchResponseItem> {
     let mut all_results: Vec<GithubSearchResponseItem> = vec![];
     let mut count = 1;
@@ -98,15 +98,23 @@ pub async fn search_pull_requests<'a>(
     }
 
     loop {
+        println!(
+            "[self-assessment] {} Attempting to collect {}...",
+            match pr_type {
+                GuardianPullRequests::AuthoredByMe => "🔎",
+                GuardianPullRequests::ReviewedByMe => "🔍",
+            },
+            pr_type
+        );
+
         params.insert("page", Cow::from(count.to_string()));
         let result: Result<GithubSearchResponse, octocrab::Error> =
             client.get("search/issues", Some(&params)).await;
         match result {
             Ok(mut response) => {
-                if !response.items.is_empty() {
-                    all_results.append(&mut response.items);
-                    count += 1;
-                } else {
+                all_results.append(&mut response.items);
+                count += 1;
+                if all_results.len() == response.total_count as usize {
                     break;
                 }
             }
@@ -121,24 +129,29 @@ pub async fn search_pull_requests<'a>(
 }
 
 pub fn format_prs(results: &[GithubSearchResponseItem]) -> Vec<TemplatePr> {
+    static OPEN_PR: &str = "<svg style=\"color: #1a7f37; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" 
+    aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 
+    0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 
+    113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 
+    0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 
+    000-1.5z\"></path></svg>";
+
+    static CLOSED_PR: &str = "<svg style=\"color: #8250df; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" 
+    aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M5 3.254V3.25v.005a.75.75 0 110-.005v.004zm.45 1.9a2.25 2.25 
+    0 10-1.95.218v5.256a2.25 2.25 0 101.5 0V7.123A5.735 5.735 0 009.25 9h1.378a2.251 2.251 0 100-1.5H9.25a4.25 4.25 0
+     01-3.8-2.346zM12.75 9a.75.75 0 100-1.5.75.75 0 000 1.5zm-8.5 4.5a.75.75 0 100-1.5.75.75 0 000 1.5z\"></path></svg>";
+
+    let base = Url::parse("https://api.github.com/repos/guardian/").unwrap();
+
     results
     .iter()
     .map(|r| {
-        let base = Url::parse("https://api.github.com/repos/guardian/").unwrap();
         let url = Url::parse(&r.repository_url.to_string()).unwrap();
         let repo_name = base.make_relative(&url).unwrap();
         let status = match r.state.as_str() {
-            "open" => "<svg style=\"color: #1a7f37; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" 
-            aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 
-            0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 
-            113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 
-            0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 
-            000-1.5z\"></path></svg>".to_string(),
-            "closed" => "<svg style=\"color: #8250df; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" 
-             aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M5 3.254V3.25v.005a.75.75 0 110-.005v.004zm.45 1.9a2.25 2.25 
-             0 10-1.95.218v5.256a2.25 2.25 0 101.5 0V7.123A5.735 5.735 0 009.25 9h1.378a2.251 2.251 0 100-1.5H9.25a4.25 4.25 0
-              01-3.8-2.346zM12.75 9a.75.75 0 100-1.5.75.75 0 000 1.5zm-8.5 4.5a.75.75 0 100-1.5.75.75 0 000 1.5z\"></path></svg>".to_string(),
-            _ => r.state.to_string()
+            "open" => OPEN_PR.to_string(),
+            "closed" => CLOSED_PR.to_string(),
+            _ => r.state.to_string(),
         };
 
         TemplatePr {
@@ -149,7 +162,10 @@ pub fn format_prs(results: &[GithubSearchResponseItem]) -> Vec<TemplatePr> {
             repo_name,
             comments: r.comments,
             comments_present: (r.comments > 0, r.comments == 1),
-            body: markdown::to_html(&r.body.to_string()),
+            body: markdown::to_html(match &r.body {
+                Some(body) => body,
+                None => "*No description provided.*",
+            }),
             labels: r.labels.iter()
                 .map(|l| format!("<span class=\"label\" style=\"color:{}; background-color: #{};\">{}</span>",
                 calc_label_colour(&String::from(&l.color)),&l.color,&l.name))
@@ -166,7 +182,7 @@ pub fn generate_html_file(
     user: octocrab::models::User,
     prs: &[TemplatePr],
     reviews: &[TemplatePr],
-    args: &crate::models::Args,
+    args: &crate::cli::Args,
 ) -> Result<(), Box<dyn Error>> {
     let mut reg = Handlebars::new();
     static TEMPLATE: &str = include_str!("./template/template.hbs");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
+pub mod cli;
 pub mod helpers;
 pub mod models;
-use crate::models::Args;
 use clap::StructOpt;
+use cli::Args;
 use helpers::*;
 use models::GuardianPullRequests;
 use octocrab::Octocrab;
@@ -12,9 +13,6 @@ use std::process::{self, Command};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
-
-    // Check if auth token exists in the user's system. If not, it must be passed
-    // as an env variable when running the executable binary
     let auth_token = get_auth_token(&args)?;
     let octocrab = Octocrab::builder().personal_token(auth_token).build()?;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,9 +1,19 @@
-use clap::Parser;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
+#[derive(Debug)]
 pub enum GuardianPullRequests {
     AuthoredByMe,
     ReviewedByMe,
+}
+
+impl Display for GuardianPullRequests {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            GuardianPullRequests::AuthoredByMe => write!(f, "pull requests authored by you"),
+            GuardianPullRequests::ReviewedByMe => write!(f, "pull requests reviewed by you"),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -14,7 +24,6 @@ pub struct GithubSearchResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-
 pub struct GithubSearchResponseItem {
     pub url: String,
     pub repository_url: String,
@@ -36,7 +45,7 @@ pub struct GithubSearchResponseItem {
     pub updated_at: String,
     pub closed_at: Option<String>,
     pub pull_request: PullRequest,
-    pub body: String,
+    pub body: Option<String>,
     pub score: f32,
     pub locked: bool,
     pub author_association: String,
@@ -49,6 +58,7 @@ pub struct PullRequest {
     pub diff_url: String,
     pub patch_url: String,
 }
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct User {
     pub login: String,
@@ -112,24 +122,4 @@ pub struct TemplatePr {
     pub labels: String,
     pub author: String,
     pub profile_pic: String,
-}
-
-// CLI struct
-#[derive(Parser, Debug, Serialize)]
-#[clap(author, version, about, long_about = None)]
-
-pub struct Args {
-    /// Match PRs that were created after this date
-    #[clap(short, long, default_value = "*")]
-    pub from: String,
-
-    /// Match PRs that were created up until this date
-    #[clap(short, long, default_value = "*")]
-    pub to: String,
-
-    /// Github authentication token. This is needed to run the CLI tool.
-    /// You can get a personal access token at https://github.com/settings/tokens/new
-    #[clap(short, long, default_value = "")]
-    #[serde(rename = "auth-token")]
-    pub auth_token: String,
 }


### PR DESCRIPTION
## [0.1.1] - 2022-02-16

### Added
- The tool now outputs descriptive status updates when running.
- The `GuardianPullRequests` enum now implements the `Display` trait.

### Changed
- In order to decrease the likelihood of hitting GitHub's secondary rate limit, the logic has been changed so that polling stops once the number of fetched items matches the number of the total items in the response. 
- The `Args` struct now lives in its own module (`cli.rs`).
- The `body` field in the `GithubSearchResponseItem` struct has been changed from a `String` type to an `Option<String>` type to account for empty PR descriptions.

### Fixed
- The new `body` type (`Option<String>`) means that execution no longer halts when encountering a pull request with an empty body.