### PR TITLE
v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
+
+## [1.0.2] - 2022-03-20
+
+### Fixed
+- The tool no longer breaks when the GitHub search response includes issues.
  
  ## [1.0.1] - 2022-03-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "self-assessment"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self-assessment"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub organisation, as well as an optional summary of the user's Trello boards and cards."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ self-assessment --trello-token <TRELLO_TOKEN>
 Running `self-assessment` from the terminal will now generate a report including Trello cards assigned to you, as well as your authored and reviewed GitHub pull requests. The `--from <YYYY-MM-DD>` and `--to <YYYY--MM-DD>` flags are fully supported.
 ## CLI information
 ```
-self-assessment 1.0.1
+self-assessment 1.0.2
 A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub
 organisation.
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -124,7 +124,7 @@ pub async fn search_pull_requests<'a>(
             params.insert(
                 "q",
                 Cow::from(format!(
-                    "author:@me org:guardian created:{}..{}",
+                    "org:guardian author:@me is:pr created:{}..{}",
                     args.from, args.to
                 )),
             );
@@ -133,7 +133,7 @@ pub async fn search_pull_requests<'a>(
             params.insert(
                 "q",
                 Cow::from(format!(
-                    "reviewed-by:@me -author:@me org:guardian created:{}..{}",
+                    "org:guardian -author:@me reviewed-by:@me is:pr created:{}..{}",
                     args.from, args.to
                 )),
             );


### PR DESCRIPTION
## [1.0.2] - 2022-03-20

### Fixed
- The tool no longer breaks when the GitHub search response includes issues.