### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [1.1.0] - 2022-03-28
+
+### Added
+- It is now possible to pass the `--skip-trello` flag (or `-s` in short) to generate a report that does not include Trello cards. 
+Previously, setting a Trello API key and a server token would always include the Trello report; the new flag overrides this behaviour.
+
+### Fixed
+- The tool no longer breaks when the GitHub search response includes pull requests with assignees.
+- If Trello authentication fails (e.g. expired server token), the program no longer terminates prematurely. Instead, an error message is displayed and the final report will not include Trello cards.
+
 ## [1.0.2] - 2022-03-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "self-assessment"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self-assessment"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 description = "A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub organisation, as well as an optional summary of the user's Trello boards and cards."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ self-assessment --trello-token <TRELLO_TOKEN>
 Running `self-assessment` from the terminal will now generate a report including Trello cards assigned to you, as well as your authored and reviewed GitHub pull requests. The `--from <YYYY-MM-DD>` and `--to <YYYY--MM-DD>` flags are fully supported.
 ## CLI information
 ```
-self-assessment 1.0.2
+self-assessment 1.1.0
 A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub
-organisation.
+organisation, as well as an optional summary of the user's Trello boards and cards.
 
 USAGE:
     self-assessment [OPTIONS]
@@ -79,7 +79,7 @@ OPTIONS:
     -a, --auth-token <AUTH_TOKEN>
             Github authentication token. This is needed for the CLI tool to access the Guardian's
             private repositories to which the user has access. You can get a personal access token
-            at https://github.com/settings/tokens/new
+            at <https://github.com/settings/tokens/new>
 
     -f, --from <FROM>
             Match PRs and Trello cards that were created after this date [default: *]
@@ -87,18 +87,22 @@ OPTIONS:
     -h, --help
             Print help information
 
+    -s, --skip-trello
+            Skip Trello report. Passing this flag generates a report that does not include Trello
+            cards
+
     -t, --to <TO>
             Match PRs and Trello cards that were created up until this date [default: *]
 
         --trello-key <TRELLO_KEY>
-            Trello API key. You can get an API key at https://trello.com/app-key Note: you need to
+            Trello API key. You can get an API key at <https://trello.com/app-key> Note: you need to
             be logged into Trello to be able to see the page. Both the API key and the server token
             need to be set for the generated report to include Trello cards
 
         --trello-token <TRELLO_TOKEN>
             Trello server token. You can get a server token by following the link at
-            https://trello.com/app-key Both the API key and the server token need to be set for the
-            generated report to include Trello cards
+            <https://trello.com/app-key> Both the API key and the server token need to be set for
+            the generated report to include Trello cards
 
     -V, --version
             Print version information

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,13 +15,13 @@ pub struct Args {
     /// Github authentication token.
     /// This is needed for the CLI tool to access
     /// the Guardian's private repositories to which the user has access.
-    /// You can get a personal access token at https://github.com/settings/tokens/new
+    /// You can get a personal access token at <https://github.com/settings/tokens/new>
     #[clap(short, long)]
     #[serde(rename = "auth-token")]
     pub auth_token: Option<String>,
 
     /// Trello API key.
-    /// You can get an API key at https://trello.com/app-key
+    /// You can get an API key at <https://trello.com/app-key>
     /// Note: you need to be logged into Trello to be able to see the page.
     /// Both the API key and the server token need to be set for the generated report
     /// to include Trello cards.
@@ -30,12 +30,18 @@ pub struct Args {
     pub trello_key: Option<String>,
 
     /// Trello server token.
-    /// You can get a server token by following the link at https://trello.com/app-key
+    /// You can get a server token by following the link at <https://trello.com/app-key>
     /// Both the API key and the server token need to be set for the generated report
     /// to include Trello cards.
     #[clap(long)]
     #[serde(rename = "trello-token")]
     pub trello_token: Option<String>,
+
+    /// Skip Trello report.
+    /// Passing this flag generates a report that does not include Trello cards.
+    #[clap(short, long)]
+    #[serde(rename = "skip-trello")]
+    pub skip_trello: bool,
 }
 
 #[derive(Debug)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -39,7 +39,7 @@ pub struct GithubSearchResponseItem {
     pub user: User,
     pub labels: Vec<Label>,
     pub state: String,
-    pub assignee: Option<String>,
+    pub assignee: Option<User>,
     pub milestone: Option<Milestone>,
     pub comments: u32,
     pub created_at: String,


### PR DESCRIPTION
## [1.1.0] - 2022-03-28

### Added
- It is now possible to pass the `--skip-trello` flag (or `-s` in short) to generate a report that does not include Trello cards. 
Previously, setting a Trello API key and a server token would always include the Trello report; the new flag overrides this behaviour.

### Fixed
- The tool no longer breaks when the GitHub search response includes pull requests with assignees.
- If Trello authentication fails (e.g. expired server token), the program no longer terminates prematurely. Instead, an error message is displayed and the final report will not include Trello cards.