### PR TITLE
v1.1.2 - display archived Trello cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
-## [1.1.2] - 2022-03-28
+## [1.1.2] - 2022-08-03
 
 ### Changed
 - Archived Trello cards are now also displayed in the Trello report.
 
 ### Fixed
 - Fixed an issue where Github IDs exceeded the storage space assigned to them.
+- Patched a [security vulnerability](https://groups.google.com/g/rustlang-security-announcements/c/NcNNL1Jq7Yw?pli=1) for the `regex` crate.
 
 ## [1.1.1] - 2022-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
+## [1.1.2] - 2022-03-28
+
+### Changed
+- Archived Trello cards are now also displayed in the Trello report.
+
 ## [1.1.1] - 2022-03-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 ### Changed
 - Archived Trello cards are now also displayed in the Trello report.
 
+### Fixed
+- Fixed an issue where Github IDs exceeded the storage space assigned to them.
+
 ## [1.1.1] - 2022-03-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "self-assessment"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "self-assessment"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub organisation, as well as an optional summary of the user's Trello boards and cards."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ self-assessment --trello-token <TRELLO_TOKEN>
 Running `self-assessment` from the terminal will now generate a report including Trello cards assigned to you, as well as your authored and reviewed GitHub pull requests. The `--from <YYYY-MM-DD>` and `--to <YYYY--MM-DD>` flags are fully supported.
 ## CLI information
 ```
-self-assessment 1.1.1
+self-assessment 1.1.2
 A CLI tool that generates a list of pull requests raised and reviewed in the Guardian's GitHub
 organisation, as well as an optional summary of the user's Trello boards and cards.
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -217,7 +217,7 @@ pub async fn search_trello(
     for (board_id, board_name) in board_ids {
         let all_cards_in_board: Vec<TrelloCard> = trello_client
         .get(format!(
-            "https://api.trello.com/1/boards/{}/cards?key={}&token={}&fields=url,idMembers,name,desc,dateLastActivity,labels", 
+            "https://api.trello.com/1/boards/{}/cards/all?key={}&token={}&fields=url,idMembers,name,desc,dateLastActivity,labels",
             board_id,
             &trello_key,
             &trello_token

--- a/src/models.rs
+++ b/src/models.rs
@@ -32,7 +32,7 @@ pub struct GithubSearchResponseItem {
     pub comments_url: String,
     pub events_url: String,
     pub html_url: String,
-    pub id: u32,
+    pub id: u64,
     pub node_id: String,
     pub number: u32,
     pub title: String,
@@ -63,7 +63,7 @@ pub struct PullRequest {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct User {
     pub login: String,
-    pub id: u32,
+    pub id: u64,
     pub node_id: String,
     pub avatar_url: String,
     pub gravatar_id: String,
@@ -83,7 +83,7 @@ pub struct User {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Label {
-    pub id: u32,
+    pub id: u64,
     pub node_id: String,
     pub url: String,
     pub name: String,
@@ -95,7 +95,7 @@ pub struct Milestone {
     pub url: String,
     pub html_url: String,
     pub labels_url: String,
-    pub id: u32,
+    pub id: u64,
     pub node_id: String,
     pub number: u32,
     pub state: String,


### PR DESCRIPTION
## What does this change?

Displays archived Trello cards - before you could only see current Trello cards.
