### PR TITLE
Update readme with authorise organisation step

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -37,6 +37,9 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 3. You can now start using the CLI tool! But first, you need to generate a GitHub personal access token 👉 [here](https://github.com/settings/tokens/new) 👈\
 This is required for the tool to access your pull requests in private repositories within the Guardian organisation.\
-Set your preferred expiration date and make sure you grant the **repo** scopes (avoid "No expiration" for security reasons). Finally, click "Generate token".\
-**NB**: You will need to re-authenticate once the token expires.
+Set your preferred expiration date and make sure you grant the **repo** scopes (avoid "No expiration" for security reasons). Then, click "Generate token".\
+Once the token is created, you may need to authorise the guardian organisation to access this token. Click "Configure SSO", then the "Authorize" button beside the guardian organisation.\
+**NB**: You will need to re-authenticate once the token expires.\
 <img width="744" alt="image" src="https://user-images.githubusercontent.com/57295823/153786937-19a8bda1-2d2c-4df2-9fd0-682b6a15228f.png">
 
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -27,7 +27,7 @@ pub fn set_credentials(
 /// Credentials live in `~/.selfassessment`
 pub fn get_auth_token(flag: AuthType) -> Option<String> {
     let credential_store_path = format!("{}/.selfassessment", shellexpand::tilde("~/"));
-    let mut credential_store = match Ini::load_from_file(&credential_store_path) {
+    let mut credential_store = match Ini::load_from_file(credential_store_path) {
         Ok(ini) => ini,
         Err(_) => Ini::new(),
     };


### PR DESCRIPTION
## What does this change?

Adds another step in the readme for using the tool. The new step is authorising the `guardian` organisation to use this token.

## Screenshots

<img width="500" alt="Screenshot 2024-05-09 at 14 55 14" src="https://github.com/guardian/self-assessment/assets/9574885/ebe06433-7d63-4e2b-81ee-a6816738eda1">
