### PR TITLE
Fix `generate-report`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
-self-assessment.html
+*self-assessment.html
+debug/

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,5 +1,6 @@
-use std::{borrow::Cow, collections::HashMap, process};
+use std::{borrow::Cow, collections::HashMap};
 
+use anyhow::Context;
 use colorsys::{Hsl, Rgb};
 use octocrab::Octocrab;
 use reqwest::Url;
@@ -10,22 +11,22 @@ use crate::models::{
 
 const GITHUB_ORG: &str = "guardian";
 
-const OPEN_PR: &str = "<svg style=\"color: #1a7f37; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" 
-aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 
-0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 
-113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 
-0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 
+const OPEN_PR: &str = "<svg style=\"color: #1a7f37; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\"
+aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25
+0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0
+113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251
+0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0
 000-1.5z\"></path></svg>";
 
-const MERGED_PR: &str = "<svg style=\"color: #8250df; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" 
-aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M5 3.254V3.25v.005a.75.75 0 110-.005v.004zm.45 1.9a2.25 2.25 
+const MERGED_PR: &str = "<svg style=\"color: #8250df; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\"
+aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M5 3.254V3.25v.005a.75.75 0 110-.005v.004zm.45 1.9a2.25 2.25
 0 10-1.95.218v5.256a2.25 2.25 0 101.5 0V7.123A5.735 5.735 0 009.25 9h1.378a2.251 2.251 0 100-1.5H9.25a4.25 4.25 0
  01-3.8-2.346zM12.75 9a.75.75 0 100-1.5.75.75 0 000 1.5zm-8.5 4.5a.75.75 0 100-1.5.75.75 0 000 1.5z\"></path></svg>";
 
-const CLOSED_PR: &str = "<svg style=\"color: #d1242f; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\" 
-aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 
-0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 
-2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 
+const CLOSED_PR: &str = "<svg style=\"color: #d1242f; margin-left:10px;\" viewBox=\"0 0 16 16\" version=\"1.1\" width=\"16\" height=\"16\"
+aria-hidden=\"true\"><path fill=\"currentColor\" d=\"M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5
+0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251
+2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75
 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z\"></path></svg>";
 
 pub fn prepare_parameters<'a>() -> HashMap<&'static str, Cow<'a, str>> {
@@ -88,20 +89,14 @@ pub async fn search_pull_requests(
         );
 
         params.insert("page", Cow::from(count.to_string()));
-        let result: Result<GithubSearchResponse, octocrab::Error> =
-            client.get("/search/issues", Some(&params)).await;
-        match result {
-            Ok(mut response) => {
-                all_results.append(&mut response.items);
-                count += 1;
-                if all_results.len() == response.total_count as usize {
-                    break;
-                }
-            }
-            Err(err) => {
-                eprintln!("{}", err);
-                process::exit(1);
-            }
+        let mut response: GithubSearchResponse = client
+            .get("/search/issues", Some(&params))
+            .await
+            .context("Failed to search issues")?;
+        all_results.append(&mut response.items);
+        count += 1;
+        if all_results.len() == response.total_count as usize {
+            break;
         }
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -89,7 +89,7 @@ pub async fn search_pull_requests(
 
         params.insert("page", Cow::from(count.to_string()));
         let result: Result<GithubSearchResponse, octocrab::Error> =
-            client.get("search/issues", Some(&params)).await;
+            client.get("/search/issues", Some(&params)).await;
         match result {
             Ok(mut response) => {
                 all_results.append(&mut response.items);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Fixes an invalid Uri error from `octocrab` by adding a leading `/` to the uri path. The `generate-report` command has presumably been broken since an upgrade to [octocrab](https://github.com/guardian/self-assessment/pull/31).

Also
- git ignore the self assessment report html and compiled files in `debug/`
- improves error handling so that the user gets a more informative error when octocrab client.get fails.

## How has this change been tested?
I generated a self assessment report!